### PR TITLE
Only draw arrows when the capsule is visible

### DIFF
--- a/Telepathy/RemoteParamAttributes.cs
+++ b/Telepathy/RemoteParamAttributes.cs
@@ -129,20 +129,20 @@ namespace Telepathy
                         this.m_stateTags.RenderStateTags(graphics);
                     }
 
+                    //figure out where to draw the arrow
+                    PointF arrowLocation = PointF.Empty;
+                    if (Owner is Param_RemoteReceiver)
+                    {
+                        arrowLocation = new PointF(bounds.Left + 10, this.OutputGrip.Y + 2);
+                    }
+                    if (Owner is Param_RemoteSender)
+                    {
+                        arrowLocation = new PointF(bounds.Right - 10, this.OutputGrip.Y + 2);
+                    }
+                    //draw the arrow
+                    if (arrowLocation != PointF.Empty) renderArrow(canvas, graphics, arrowLocation);
                 }
 
-                //figure out where to draw the arrow
-                PointF arrowLocation = PointF.Empty;
-                if (Owner is Param_RemoteReceiver)
-                {
-                    arrowLocation = new PointF(bounds.Left + 10, this.OutputGrip.Y + 2);
-                }
-                if (Owner is Param_RemoteSender)
-                {
-                    arrowLocation = new PointF(bounds.Right - 10, this.OutputGrip.Y + 2);
-                }
-                //draw the arrow
-                if (arrowLocation != PointF.Empty) renderArrow(canvas, graphics, arrowLocation);
             }
 
         }


### PR DESCRIPTION
Hey @andrewheumann,

Hope all is well! 

This should fix the performance issue (mainly on Mac) when using a lot of Telepathy components that was reported by Rudi.  If you could publish a new version with this fix up to Food4Rhino or PackageManager I'm sure he'd appreciate it greatly!

Cheers,
Curtis.