### PR TITLE
Fixed the scaling issues, though it required upgrade to .net 4.7

### DIFF
--- a/Telepathy/Properties/Resources.Designer.cs
+++ b/Telepathy/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace Telepathy.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {

--- a/Telepathy/RemoteParamAttributes.cs
+++ b/Telepathy/RemoteParamAttributes.cs
@@ -40,7 +40,8 @@ namespace Telepathy
         protected override void Layout()
         {
             //establish the size based on the text content
-            float textWidth = (float)System.Math.Max(GH_FontServer.MeasureString(this.Owner.NickName, GH_FontServer.StandardBold).Width + 10, 50);
+            float baseTextWidth = GH_FontServer.MeasureString(this.Owner.NickName, GH_FontServer.StandardBold).Width / TelepathyUtils.resolutionScale;
+            float textWidth = (float)System.Math.Max(baseTextWidth + 10, 50);
             System.Drawing.RectangleF bounds = new System.Drawing.RectangleF(this.Pivot.X - 0.5f * textWidth, this.Pivot.Y - 10f, textWidth, 20f);
             this.Bounds = bounds;
             this.Bounds = GH_Convert.ToRectangle(this.Bounds);
@@ -155,7 +156,7 @@ namespace Telepathy
             //  Font font = new Font("Wingdings 3", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(2)));
             //render the text at specified location
             //Version for everyone:
-            GH_GraphicsUtil.RenderCenteredText(graphics, "\u2192", new Font("Arial", 10F), Color.Black, new PointF(loc.X, loc.Y - 1.5f));
+            GH_GraphicsUtil.RenderCenteredText(graphics, "\u2192", new Font("Arial", 10f/TelepathyUtils.resolutionScale), Color.Black, new PointF(loc.X, loc.Y - 1.5f));
             //Version for Marc:
            // GH_GraphicsUtil.RenderCenteredText(graphics, "*", new Font("Arial", 10F), Color.Black, loc);
         }

--- a/Telepathy/Telepathy.csproj
+++ b/Telepathy/Telepathy.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug64</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Telepathy</RootNamespace>
     <AssemblyName>Telepathy</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <TargetFrameworkProfile />
@@ -102,5 +102,9 @@
     </StartArguments>
     <StartAction>Program</StartAction>
     <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup>
+    <PostBuildEvent>Copy "$(TargetPath)" "$(TargetDir)$(ProjectName).gha"
+Erase "$(TargetPath)"</PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/Telepathy/TelepathyUtils.cs
+++ b/Telepathy/TelepathyUtils.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using System.Text;
 using System.Windows.Forms;
 using Microsoft.VisualBasic.CompilerServices;
-
+using Microsoft.Win32;
 namespace Telepathy
 {
     public static class TelepathyUtils
@@ -17,6 +17,29 @@ namespace Telepathy
             connectMatchingParams(doc);
            if(scheduleNew) Grasshopper.Instances.ActiveCanvas.Document.ScheduleSolution(10);
         }
+
+
+        //Method for establishing windows resolution scaling. From debugging this is called when the 
+        //property is first required, e.g. when telepathy object is dropped onto canvas after GH is 
+        //first opended
+        private static float getResolutionScale()
+        {
+            try
+            {
+                var canvasDPI = Grasshopper.Instances.ActiveCanvas.DeviceDpi;
+                return canvasDPI / 96.0f;
+            }
+            catch 
+            {
+                return 1.0f;
+            }
+        }
+
+        //Field for storing the scale, at the moment this is fixed for the lifetime of the GH
+        //Weirdly it still seems to work if you change the scale mid Rhino session, it looks like
+        //windows just applies a scale on all the pixels in Rhino if you do this - the UI looks 
+        //scaled to me.
+        public static readonly float resolutionScale = getResolutionScale();
 
         //the main method that does the work - checks all receivers and senders for matches,
         //and rewires accordingly.


### PR DESCRIPTION
Had to upgrade this to .Net 4.7 to access DeviceDpi windows forms property. Not sure if this will still work with Rhino 6, I think that is all .Net 4.5? not my area of expertise really. 

The arrow was rendering a bit large so I fixed that too. 

I've run some basic tests - it is behaving the same on 100% scaling mode as the release version. On 150% scaling mode the fix appears to be working. 

Here are some pictures:

150% scaling before:
<img width="572" alt="Telepathy before fix" src="https://user-images.githubusercontent.com/64376451/204664776-a9c93ec7-b240-46b1-ba9c-591ffb85374f.png">

150% scaling after:
<img width="730" alt="150 percent fixed with arrow fixed" src="https://user-images.githubusercontent.com/64376451/204664818-0e5328f3-424d-4e63-a2b3-bd25e49bc3f8.png">

100% scaling after:
![Telepathy with fix 100 percent scaling](https://user-images.githubusercontent.com/64376451/204664879-51fdda42-c330-4c38-bd94-36b710badb8c.png)
